### PR TITLE
MAINT: Fix bug with version metadata

### DIFF
--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -2,8 +2,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -22,6 +20,3 @@ python:
 - 3.11.* *_cpython
 target_platform:
 - linux-64
-zip_keys:
-- - python
-  - channel_sources

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -2,8 +2,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -22,6 +20,3 @@ python:
 - 3.12.* *_cpython
 target_platform:
 - linux-64
-zip_keys:
-- - python
-  - channel_sources

--- a/.ci_support/linux_64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_python3.13.____cp313.yaml
@@ -2,8 +2,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -22,6 +20,3 @@ python:
 - 3.13.* *_cp313
 target_platform:
 - linux-64
-zip_keys:
-- - python
-  - channel_sources

--- a/.ci_support/linux_64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_64_python3.14.____cp314.yaml
@@ -2,10 +2,8 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
-- conda-forge,conda-forge/label/python_rc
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -22,6 +20,3 @@ python:
 - 3.14.* *_cp314
 target_platform:
 - linux-64
-zip_keys:
-- - python
-  - channel_sources

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -2,8 +2,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -22,6 +20,3 @@ python:
 - 3.11.* *_cpython
 target_platform:
 - linux-aarch64
-zip_keys:
-- - python
-  - channel_sources

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -2,8 +2,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -22,6 +20,3 @@ python:
 - 3.12.* *_cpython
 target_platform:
 - linux-aarch64
-zip_keys:
-- - python
-  - channel_sources

--- a/.ci_support/linux_aarch64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_python3.13.____cp313.yaml
@@ -2,8 +2,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -22,6 +20,3 @@ python:
 - 3.13.* *_cp313
 target_platform:
 - linux-aarch64
-zip_keys:
-- - python
-  - channel_sources

--- a/.ci_support/linux_aarch64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_aarch64_python3.14.____cp314.yaml
@@ -2,10 +2,8 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
-- conda-forge,conda-forge/label/python_rc
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -22,6 +20,3 @@ python:
 - 3.14.* *_cp314
 target_platform:
 - linux-aarch64
-zip_keys:
-- - python
-  - channel_sources

--- a/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
@@ -2,8 +2,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -22,6 +20,3 @@ python:
 - 3.11.* *_cpython
 target_platform:
 - linux-ppc64le
-zip_keys:
-- - python
-  - channel_sources

--- a/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
@@ -2,8 +2,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -22,6 +20,3 @@ python:
 - 3.12.* *_cpython
 target_platform:
 - linux-ppc64le
-zip_keys:
-- - python
-  - channel_sources

--- a/.ci_support/linux_ppc64le_python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_python3.13.____cp313.yaml
@@ -2,8 +2,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -22,6 +20,3 @@ python:
 - 3.13.* *_cp313
 target_platform:
 - linux-ppc64le
-zip_keys:
-- - python
-  - channel_sources

--- a/.ci_support/linux_ppc64le_python3.14.____cp314.yaml
+++ b/.ci_support/linux_ppc64le_python3.14.____cp314.yaml
@@ -2,10 +2,8 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
-- conda-forge,conda-forge/label/python_rc
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -22,6 +20,3 @@ python:
 - 3.14.* *_cp314
 target_platform:
 - linux-ppc64le
-zip_keys:
-- - python
-  - channel_sources

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -24,6 +24,3 @@ python:
 - 3.11.* *_cpython
 target_platform:
 - osx-64
-zip_keys:
-- - python
-  - channel_sources

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -24,6 +24,3 @@ python:
 - 3.12.* *_cpython
 target_platform:
 - osx-64
-zip_keys:
-- - python
-  - channel_sources

--- a/.ci_support/osx_64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_python3.13.____cp313.yaml
@@ -24,6 +24,3 @@ python:
 - 3.13.* *_cp313
 target_platform:
 - osx-64
-zip_keys:
-- - python
-  - channel_sources

--- a/.ci_support/osx_64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_64_python3.14.____cp314.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '10.13'
 channel_sources:
-- conda-forge,conda-forge/label/python_rc
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -24,6 +24,3 @@ python:
 - 3.14.* *_cp314
 target_platform:
 - osx-64
-zip_keys:
-- - python
-  - channel_sources

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -24,6 +24,3 @@ python:
 - 3.11.* *_cpython
 target_platform:
 - osx-arm64
-zip_keys:
-- - python
-  - channel_sources

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -24,6 +24,3 @@ python:
 - 3.12.* *_cpython
 target_platform:
 - osx-arm64
-zip_keys:
-- - python
-  - channel_sources

--- a/.ci_support/osx_arm64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313.yaml
@@ -24,6 +24,3 @@ python:
 - 3.13.* *_cp313
 target_platform:
 - osx-arm64
-zip_keys:
-- - python
-  - channel_sources

--- a/.ci_support/osx_arm64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_arm64_python3.14.____cp314.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge,conda-forge/label/python_rc
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -24,6 +24,3 @@ python:
 - 3.14.* *_cp314
 target_platform:
 - osx-arm64
-zip_keys:
-- - python
-  - channel_sources

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -14,6 +14,3 @@ python:
 - 3.11.* *_cpython
 target_platform:
 - win-64
-zip_keys:
-- - python
-  - channel_sources

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -14,6 +14,3 @@ python:
 - 3.12.* *_cpython
 target_platform:
 - win-64
-zip_keys:
-- - python
-  - channel_sources

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -14,6 +14,3 @@ python:
 - 3.13.* *_cp313
 target_platform:
 - win-64
-zip_keys:
-- - python
-  - channel_sources

--- a/.ci_support/win_64_python3.14.____cp314.yaml
+++ b/.ci_support/win_64_python3.14.____cp314.yaml
@@ -1,7 +1,7 @@
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge,conda-forge/label/python_rc
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -14,6 +14,3 @@ python:
 - 3.14.* *_cp314
 target_platform:
 - win-64
-zip_keys:
-- - python
-  - channel_sources

--- a/README.md
+++ b/README.md
@@ -280,12 +280,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -312,7 +312,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/antio-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - pip
     - python
     - setuptools >=64.0.0
+    - setuptools_scm >=8.0.0
   run:
     - click
     - numpy >=1.23

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: bf090de52857fda89dd017d29d9614008e1df94de3fbf1f3bf60cbe24b6190d0
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   skip: true  # [py<311]
   entry_points:
@@ -41,6 +41,8 @@ test:
   commands:
     - pip check
     - python -c "from antio.libeep import pyeep; version = pyeep.get_version(); assert version == '3.3.179', version"
+    - python -c "ver = importlib.metadata.version('antio'); assert ver == '{{ version }}', ver"
+    - python -c "import antio; ver = antio.__version__; assert ver == '{{ version }}', ver"
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ test:
   commands:
     - pip check
     - python -c "from antio.libeep import pyeep; version = pyeep.get_version(); assert version == '3.3.179', version"
-    - python -c "ver = importlib.metadata.version('antio'); assert ver == '{{ version }}', ver"
+    - python -c "import importlib.metadata; ver = importlib.metadata.version('antio'); assert ver == '{{ version }}', ver"
     - python -c "import antio; ver = antio.__version__; assert ver == '{{ version }}', ver"
   requires:
     - pip


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] ~~Reset the build number to `0` (if the version changed)~~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
on macOS
```
$ conda install antio
$ python
>>> import antio
>>> antio.__version__
'0.6.1'
$ pip list | grep antio
antio                         0.0.0
$ $ ls /Applications/MNE-Python/1.9.0_0/.mne-python/lib/python3.13/site-packages/antio
antio/                 antio-0.0.0.dist-info/
```
so even though `__version__` is correct, the metadata is wrong.

It's okay for the wheel:

<img width="479" height="144" alt="Image" src="https://github.com/user-attachments/assets/caf992a9-fb0a-4e8f-9c01-d7f15983d387" />

Suggesting it's something about the `sdist`. Checking:
```
$ wget https://files.pythonhosted.org/packages/c2/5d/46680f78ed127e15f980fe505796c48f9cb3061844bde31321b40a05ba85/antio-0.6.1.tar.gz
$ tar xzfv antio-0.6.1.tar.gz 
$ cd antio-0.6.1/
$ python -m build .
$ cd dist
$ unzip antio-0.6.1-cp311-abi3-macosx_26_0_arm64.whl
...
  inflating: antio-0.6.1.dist-info/licenses/LICENSE  
```
Maybe it's because `setuptools_scm>=8` is missing from the conda-forge recipe? Anyway I've pushed a commit that should show the issue, then I'll try to fix it.